### PR TITLE
:green_heart: Fix Caddy config validation step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Test Config
         run: |
           docker run --rm -i ${{ steps.docker_build_test.outputs.imageid }} \
-            caddy validate -config /etc/caddy/Caddyfile
+            caddy validate --config /etc/caddy/Caddyfile
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
A recent Caddy upgrade broke the CI config validation step. Flags now require a double dash instead of a single dash. This PR fixes these failures.